### PR TITLE
Add override for Workflow editing

### DIFF
--- a/assets/components/resourceselectinput/js/inputs/resourceselect.input.js
+++ b/assets/components/resourceselectinput/js/inputs/resourceselect.input.js
@@ -18,7 +18,7 @@
             this.filter = dom.find('.contentblocks-field-resourceselect input');
             var contextkey = this.filter.data('contextkey');
             var template = this.filter.data('template');
-            var id = this.filter.data('id');
+            var id = (Preview && Preview.resource && Preview.resource.isRevision) ? Preview.resource.isRevision : this.filter.data('id');
             this.filter.on('keyup', $.proxy(function() {
                 this.updateList(this.filter.val(),contextkey,template,id);
                 this.select.prop("size", 10);


### PR DESCRIPTION
# Why it's needed
If you are using the [Workflow extra](https://extras.io/extras/workflow/) every time you edit a resource it creates a copy of the original resource (revision) that you edit and only when the revision is approved does it replace the original. If you have a constraints based on the current resource's id, it will not work when you try to select resources while editing the revision.

# What it does
It checks if the current resource is a revision and if it is, substitutes the id passed to the connector with the original (source) resource's id.